### PR TITLE
add prompt dialog label CSS for polkit auth dialog text visibility

### DIFF
--- a/theme/gnome-shell/.css/modal.css
+++ b/theme/gnome-shell/.css/modal.css
@@ -31,6 +31,36 @@
 	padding: 8px !important;
 }
 
+/* prompt dialog labels (polkit auth - fingerprint, error messages) */
+.prompt-dialog .prompt-dialog-error-label,
+.prompt-dialog .prompt-dialog-info-label,
+.prompt-dialog .prompt-dialog-null-label {
+	text-align: center;
+	padding: 9px;
+	border-radius: 8px;
+	margin: 4px 0;
+}
+.prompt-dialog .prompt-dialog-error-label {
+	color: #cd9309;
+	background-color: rgba(205, 147, 9, 0.1);
+}
+.prompt-dialog .prompt-dialog-info-label {
+	color: TEXT-PRIMARY-COLOR;
+	background-color: BORDER-MENU-SHADOW;
+}
+
+/* run dialog (Alt+F2) */
+.run-dialog {
+	width: 24em;
+	padding-bottom: 6px;
+}
+.run-dialog .run-dialog-entry {
+	padding: 12px 9px;
+}
+.run-dialog .run-dialog-description {
+	color: TEXT-SECONDARY-COLOR;
+}
+
 
 /* button in modals */
 .modal-dialog-linked-button, /* 46 */


### PR DESCRIPTION
Fixes text visibility on dark mode in polkit auth:
- without
<img width="474" height="393" alt="Screenshot From 2026-06-18 20-54-16" src="https://github.com/user-attachments/assets/924a3ce8-2c49-4347-8630-ef2c777ab9f5" />

- fixed
<img width="474" height="393" alt="Screenshot From 2026-06-18 21-02-17" src="https://github.com/user-attachments/assets/2e6b0a14-e563-4080-a55a-91c0b6912d62" />


- run dialog:
<img width="379" height="274" alt="Screenshot From 2026-06-18 22-03-11" src="https://github.com/user-attachments/assets/d2629aad-6763-45a7-9e01-e3c319096fe6" />
<img width="379" height="274" alt="Screenshot From 2026-06-18 22-25-39" src="https://github.com/user-attachments/assets/9e5090b2-88fd-4532-9115-05a3341d99a8" />
